### PR TITLE
Cleanup appveyor.yml file

### DIFF
--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -1,5 +1,8 @@
 cd %APPVEYOR_BUILD_FOLDER%
 
+:: Make VS 2013 command line tools available
+call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %platform%
+
 :: Download and compile Lua
 appveyor DownloadFile %LUAURL%/lua-%LUA_VER%.tar.gz
 7z x lua-%LUA_VER%.tar.gz
@@ -28,5 +31,4 @@ set LUA_PATH=%ProgramFiles(x86)%\LuaRocks\%LUAROCKS_SHORTV%\lua\?.lua;%ProgramFi
 set LUA_CPATH=%ProgramFiles(x86)%\LuaRocks\systree\lib\lua\%LUA_SHORTV%\?.dll
 call luarocks --version
 
-:: Install telescope, but you can pick any other test library
-call luarocks install telescope
+cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,26 +16,26 @@ environment:
   - LUA_VER: 5.1.5
     LUA_SHORTV: 5.1
 
-  - LUA_VER: 5.2.4
-    LUA_SHORTV: 5.2
+  # - LUA_VER: 5.2.4
+  #   LUA_SHORTV: 5.2
 
-  - LUA_VER: 5.3.0
-    LUA_SHORTV: 5.3
-
-
-init:
-# Make VS 2013 command line tools available
-- '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %platform%'
+  # - LUA_VER: 5.3.0
+  #   LUA_SHORTV: 5.3
 
 install:
-- echo "Installing..."
-- cd %APPVEYOR_BUILD_FOLDER%
+# Setup Lua development/build environment
 - call .appveyor\install.bat
 
+before_build:
+# @todo
+- echo "Installing external deps"
+
 build_script:
-- echo "Building..."
-- cd %APPVEYOR_BUILD_FOLDER%
-- call .appveyor\build.bat
+- call luarocks make rockspecs/foo-scm-0.rockspec
+
+before_test:
+# install test only deps
+- call luarocks install telescope
 
 test_script:
 - echo "Testing..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,13 +31,13 @@ before_build:
 - echo "Installing external deps"
 
 build_script:
-- call luarocks make rockspecs/foo-scm-0.rockspec
+- luarocks make rockspecs/foo-scm-0.rockspec
 
 before_test:
 # install test only deps
-- call luarocks install telescope
+- luarocks install telescope
 
 test_script:
 - echo "Testing..."
 - cd %APPVEYOR_BUILD_FOLDER%\test
-- echo "Run your tests"
+- tsc test.lua

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,4 +40,4 @@ before_test:
 test_script:
 - echo "Testing..."
 - cd %APPVEYOR_BUILD_FOLDER%\test
-- tsc test.lua
+- tsc.bat test.lua

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,11 @@ environment:
   - LUA_VER: 5.1.5
     LUA_SHORTV: 5.1
 
-  # - LUA_VER: 5.2.4
-  #   LUA_SHORTV: 5.2
+  - LUA_VER: 5.2.4
+    LUA_SHORTV: 5.2
 
-  # - LUA_VER: 5.3.0
-  #   LUA_SHORTV: 5.3
+  - LUA_VER: 5.3.0
+    LUA_SHORTV: 5.3
 
 install:
 # Setup Lua development/build environment

--- a/test/test.lua
+++ b/test/test.lua
@@ -5,16 +5,15 @@ context("Foo test", function()
     assert_false(false)
   end)
 
-  test("export functions", function()
+  test("assert_true test", function()
     local foo = require "foo"
-    assert_function(foo.test_true)
+    assert_type(foo.test_true, 'function')
     assert_true(foo.test_true())
   end)
 
-  test("foo module", function()
+  test("assert_false test", function()
     local foo = require "foo"
-    assert_function(foo.test_false)
+    assert_type(foo.test_false, 'function')
     assert_false(foo.test_false())
   end)
 end)
-

--- a/test/test.lua
+++ b/test/test.lua
@@ -1,0 +1,20 @@
+local tsc = require "telescope"
+
+context("Foo test", function()
+  test("basic test", function()
+    assert_false(false)
+  end)
+
+  test("export functions", function()
+    local foo = require "foo"
+    assert_function(foo.test_true)
+    assert_true(foo.test_true())
+  end)
+
+  test("foo module", function()
+    local foo = require "foo"
+    assert_function(foo.test_false)
+    assert_false(foo.test_false())
+  end)
+end)
+


### PR DESCRIPTION
I think `.appveyor/*` should contain only common commands to install Lua environment.
But installing module and its Lua deps better place in yml file. And if installing some deps is quite verbosy better provide separate command file for it and leave intact existing `.appveyor/*` files.
But if install is just luarocks command it more clear use it directly.

Also I add basic telescope test.