### PR TITLE
copy luajit.exe lua.exe; remove trailing spaces

### DIFF
--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -77,6 +77,7 @@ if "%LUA%"=="luajit" (
 		for %%a in (bin bin\lua bin\lua\jit include lib) do ( mkdir "%LUA_DIR%\%%a" )
 
 		for %%a in (luajit.exe lua51.dll) do ( move "!lj_source_folder!\src\%%a" "%LUA_DIR%\bin" )
+		copy "%LUA_DIR%\bin\luajit.exe" "%LUA_DIR%\bin\lua.exe"
 
 		move "!lj_source_folder!\src\lua51.lib" "%LUA_DIR%\lib"
 		for %%a in (lauxlib.h lua.h lua.hpp luaconf.h lualib.h luajit.h) do (

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -83,7 +83,7 @@ if "%LUA%"=="luajit" (
 		for %%a in (lauxlib.h lua.h lua.hpp luaconf.h lualib.h luajit.h) do (
 			copy "!lj_source_folder!\src\%%a" "%LUA_DIR%\include"
 		)
-		
+
 		copy "!lj_source_folder!\src\jit\*.lua" "%LUA_DIR%\bin\lua\jit"
 
 	) else (
@@ -95,7 +95,7 @@ if "%LUA%"=="luajit" (
 		if not exist downloads\lua-%LUA_VER% (
 			curl --silent --fail --max-time 120 --connect-timeout 30 %LUA_URL%/lua-%LUA_VER%.tar.gz | %SEVENZIP% x -si -so -tgzip | %SEVENZIP% x -si -ttar -aoa -odownloads
 		)
-		
+
 		mkdir downloads\lua-%LUA_VER%\etc 2> NUL
 		if not exist downloads\lua-%LUA_VER%\etc\winmake.bat (
 			curl --silent --location --insecure --fail --max-time 120 --connect-timeout 30 https://github.com/Tieske/luawinmake/archive/master.tar.gz | %SEVENZIP% x -si -so -tgzip | %SEVENZIP% e -si -ttar -aoa -odownloads\lua-%LUA_VER%\etc luawinmake-master\etc\winmake.bat
@@ -125,7 +125,7 @@ if not exist "%LR_ROOT%" (
 	cd %APPVEYOR_BUILD_FOLDER%
 
 	if not exist downloads\luarocks-%LUAROCKS_VER%-win32.zip (
-		echo Downloading LuaRocks... 
+		echo Downloading LuaRocks...
 		curl --silent --fail --max-time 120 --connect-timeout 30 --output downloads\luarocks-%LUAROCKS_VER%-win32.zip %LUAROCKS_URL%/luarocks-%LUAROCKS_VER%-win32.zip
 		%SEVENZIP% x -aoa -odownloads downloads\luarocks-%LUAROCKS_VER%-win32.zip
 	)


### PR DESCRIPTION
This allows to write Lua implementation agnostic commands. Use command "lua" in tests even if LUA=luajit.